### PR TITLE
Update build.default.properties

### DIFF
--- a/buildfiles/linux/raspbian/build.default.properties
+++ b/buildfiles/linux/raspbian/build.default.properties
@@ -19,7 +19,7 @@ php-fpm.user = www-data
 php-fpm.group = www-data
 
 # ---- Path of the ldap lib -----------------------------------------------------
-libldap.dir = ${os.architecture}-linux-gnu
+libldap.dir = ${os.architecture}-linux-gnueabihf
 
 # ---- Set the distribution specific package information ------------------------
 dist.package.suffix-separator = +


### PR DESCRIPTION
The ldap-libraries are installed to `/usr/lib/arm-linux-gnueabihf` instead of `/usr/lib/arm-linux-gnu`